### PR TITLE
Add image preview for uploaded images in create poll form

### DIFF
--- a/src/components/admin/CreatePollForm/components/WithImageInput/index.tsx
+++ b/src/components/admin/CreatePollForm/components/WithImageInput/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styles from "../index.module.css";
 import { MdOutlineAddPhotoAlternate } from "react-icons/md";
 import { IoMdClose } from "react-icons/io";
@@ -24,6 +24,20 @@ const WithImageInput = ({
   file,
   ...rest
 }: WithImageInputProps) => {
+  const [preview, setPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setPreview(null);
+    }
+  }, [file]);
+
   return (
     <div className={`${styles["with-img-input"]} ${className}`}>
       <input
@@ -36,6 +50,7 @@ const WithImageInput = ({
       <div className={styles["file-input-container"]}>
         {file ? (
           <div className={styles["selected-file"]}>
+            {preview && <img src={preview} alt="Preview" className={styles["image-preview"]} />}
             <span className={styles["file-name"]}>{file.name}</span>
             <button 
               onClick={onFileRemove}

--- a/src/components/admin/CreatePollForm/components/index.module.css
+++ b/src/components/admin/CreatePollForm/components/index.module.css
@@ -117,3 +117,10 @@
 .remove-file-btn:hover {
   background-color: rgba(239, 68, 68, 0.1);
 }
+
+.image-preview {
+  max-width: 100px;
+  max-height: 100px;
+  border-radius: 8px;
+  margin-right: 8px;
+}


### PR DESCRIPTION
Add image preview functionality for uploaded images in the poll creation feature.

* Update `src/components/admin/CreatePollForm/components/WithImageInput/index.tsx` to include image preview logic and display the preview of the uploaded image.
* Add CSS styling for the `image-preview` class in `src/components/admin/CreatePollForm/components/index.module.css` to improve the UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PriVote-Project/privote-frontend/pull/1?shareId=793915d5-1b7b-43fe-864f-66732295a291).